### PR TITLE
Bug 1

### DIFF
--- a/src/components/InputSelect/index.tsx
+++ b/src/components/InputSelect/index.tsx
@@ -71,7 +71,7 @@ export function InputSelect<TItem>({
                 "RampInputSelect--dropdown-container-opened": isOpen,
               })}
               {...getMenuProps()}
-              style={{ top: dropdownPosition.top, left: dropdownPosition.left }}
+              /*style={{ top: dropdownPosition.top, left: dropdownPosition.left }}*/
             >
               {renderItems()}
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,7 @@ hr.RampBreak--l {
 
 .RampInputSelect--root {
   width: 100%;
+  position: relative;
 }
 
 .RampInputSelect--input {
@@ -100,6 +101,8 @@ hr.RampBreak--l {
   max-height: 16rem;
   overflow: auto;
   box-shadow: rgb(0 0 0 / 10%) 0px 0px 1px, rgb(0 0 0 / 13%) 0px 4px 8px;
+
+  position:absolute;
 }
 
 .RampInputSelect--dropdown-container-opened {


### PR DESCRIPTION
Bug 1: Select dropdown doesn't scroll with rest of the page
How to reproduce:

Make your viewport smaller in height. Small enough to have a scroll bar
Click on the Filter by employee select to open the options dropdown
Scroll down the page
Expected: Options dropdown moves with its parent input as you scroll the page

Actual: Options dropdown stays in the same position as you scroll the page, losing the reference to the select input