### PR TITLE
Bug-3

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,10 @@ export function App() {
             if (newValue === null) {
               return
             }
+            else if(newValue.id === ""){
+              await loadAllTransactions()
+              return;
+            }
 
             await loadTransactionsByEmployee(newValue.id)
           }}


### PR DESCRIPTION
Bug 3: Cannot select All Employees after selecting an employee
How to reproduce:

Click on the Filter by employee select to open the options dropdown
Select an employee from the list
Click on the Filter by employee select to open the options dropdown
Select All Employees option
Expected: All transactions are loaded

Actual: The page crashes