### PR TITLE
Bug-4

### DIFF
--- a/src/hooks/usePaginatedTransactions.ts
+++ b/src/hooks/usePaginatedTransactions.ts
@@ -21,8 +21,8 @@ export function usePaginatedTransactions(): PaginatedTransactionsResult {
       if (response === null || previousResponse === null) {
         return response
       }
-
-      return { data: response.data, nextPage: response.nextPage }
+      
+      return { data: previousResponse.data.concat(response.data), nextPage: response.nextPage }
     })
   }, [fetchWithCache, paginatedTransactions])
 


### PR DESCRIPTION
Bug 4: Clicking on View More button not showing correct data
How to reproduce:

Click on the View more button
Wait until the new data loads
Expected: Initial transactions plus new transactions are shown on the page

Actual: New transactions replace initial transactions, losing initial transactions