### PR TITLE
Bug-5

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,9 +24,8 @@ export function App() {
     transactionsByEmployeeUtils.invalidateData()
 
     await employeeUtils.fetchAll()
-    await paginatedTransactionsUtils.fetchAll()
-
     setIsLoading(false)
+    await paginatedTransactionsUtils.fetchAll()
   }, [employeeUtils, paginatedTransactionsUtils, transactionsByEmployeeUtils])
 
   const loadTransactionsByEmployee = useCallback(


### PR DESCRIPTION
Bug 5: Employees filter not available during loading more data
This bug has 2 wrong behaviors that will be fixed with the same solution

Part 1
How to reproduce:

Open devtools to watch the simulated network requests in the console
Refresh the page
Quickly click on the Filter by employee select to open the options dropdown
Expected: The filter should stop showing "Loading employees.." as soon as the request for employees is succeeded

Actual: The filter stops showing "Loading employees.." until paginatedTransactions is succeeded

Part 2
How to reproduce:

Open devtools to watch the simulated network requests in the console
Click on View more button
Quickly click on the Filter by employee select to open the options dropdown
Expected: The employees filter should not show "Loading employees..." after clicking View more, as employees are already loaded

Actual: The employees filter shows "Loading employees..." after clicking View more until new transactions are loaded.