### PR TITLE
Bug-6

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ export function App() {
   const { data: paginatedTransactions, ...paginatedTransactionsUtils } = usePaginatedTransactions()
   const { data: transactionsByEmployee, ...transactionsByEmployeeUtils } = useTransactionsByEmployee()
   const [isLoading, setIsLoading] = useState(false)
+  const [empID, setEmpID] = useState("")
 
   const transactions = useMemo(
     () => paginatedTransactions?.data ?? transactionsByEmployee ?? null,
@@ -64,9 +65,11 @@ export function App() {
               return
             }
             else if(newValue.id === ""){
+              setEmpID(newValue.id)
               await loadAllTransactions()
               return;
             }
+            setEmpID(newValue.id)
 
             await loadTransactionsByEmployee(newValue.id)
           }}
@@ -77,7 +80,7 @@ export function App() {
         <div className="RampGrid">
           <Transactions transactions={transactions} />
 
-          {transactions !== null && (
+          {paginatedTransactions?.nextPage !== null && empID === "" && (
             <button
               className="RampButton"
               disabled={paginatedTransactionsUtils.loading}


### PR DESCRIPTION
Bug 6: View more button not working as expected
This bug has 2 wrong behaviors that can be fixed with the same solution. It's acceptable to fix with separate solutions as well.

Part 1
How to reproduce:

Click on the Filter by employee select to open the options dropdown
Select an employee from the list
Wait until transactions load
Expected: The View more button is not be visible when transactions are filtered by user, because that is not a paginated request.

Actual: The View more button is visible even when transactions are filtered by employee. You can even click View more button and get an unexpected result

Part 2
How to reproduce:

Click on View more button
Wait until it loads more data
Repeat these steps as many times as you can
Expected: When you reach the end of the data, the View More button disappears and you are not able to request more data.

Actual: When you reach the end of the data, the View More button is still showing and you are still able to click the button. If you click it, the page crashes.